### PR TITLE
simpler format for "AI Safety Exposure"

### DIFF
--- a/hsresumebuilder.yaml
+++ b/hsresumebuilder.yaml
@@ -241,13 +241,13 @@ hsResumeBuilder:
     aiSafetyExposure:
       - year: "2025"
         description: "Interactive demo: using Range Analysis to prove the safety of a toy example"
-        url: "https://gelisam.com/range-analysis"
+        url: "gelisam.com/range-analysis"
       - year: "2025"
         description: "Applied to Safeguarded AI TA1.2 as part of GLAIVe Research"
         url: null
       - year: "2022"
         description: "Invited talk at Galois, \"Can we Prove Facts about ML Models via Code Synthesis?\""
-        url: "https://youtu.be/-2nFTfXAsmU"
+        url: "youtu.be/-2nFTfXAsmU"
       - year: "2019"
         description: "Answered AI Safety questions from comments on Rob Miles's YouTube videos as part of his Patreon-only Discord server"
         url: null

--- a/hsresumebuilder.yaml
+++ b/hsresumebuilder.yaml
@@ -239,18 +239,18 @@ hsResumeBuilder:
         timeWorked: "10+ years combined"
 
     aiSafetyExposure:
-      - entityName: "LessWrong Community"
-        technologies: "Rationality, decision theory, AI alignment research"
-        responsibilities: "Community participation, critical thinking, research discussion"
-        expertise: "AI safety concepts, rationality techniques, existential risk assessment"
-        positionName:
-          - "Early community member"
-        timeWorked: "2009 – 2014"
-      - entityName: "Machine Learning Research"
-        technologies: "NLP, AI safety considerations in ML systems"
-        responsibilities: "Integrating safety considerations into ML workflows"
-        expertise: "Understanding AI safety implications in practical systems"
-        contexts: "Applied ML in industry contexts with safety awareness"
-        positionName:
-          - "ML-aware engineer"
-        timeWorked: "2015 – present"
+      - year: "2025"
+        description: "Interactive demo: using Range Analysis to prove the safety of a toy example"
+        url: "https://gelisam.com/range-analysis"
+      - year: "2025"
+        description: "Applied to Safeguarded AI TA1.2 as part of GLAIVe Research"
+        url: null
+      - year: "2022"
+        description: "Invited talk at Galois, \"Can we Prove Facts about ML Models via Code Synthesis?\""
+        url: "https://youtu.be/-2nFTfXAsmU"
+      - year: "2019"
+        description: "Answered AI Safety questions from comments on Rob Miles's YouTube videos as part of his Patreon-only Discord server"
+        url: null
+      - year: "2009-2014"
+        description: "Forum participant on lesswrong.com"
+        url: null

--- a/src/ResumeBuilder/ResumeBuilderModel.hs
+++ b/src/ResumeBuilder/ResumeBuilderModel.hs
@@ -30,7 +30,14 @@ data Preferences = Preferences
     praise :: [GenericItem],
     publications :: [GenericItem],
     programmingLanguageExperience :: [ExperienceItem],
-    aiSafetyExposure :: [ExperienceItem]
+    aiSafetyExposure :: [AISafetyItem]
+  }
+  deriving (Generic, Show, ToJSON, FromJSON)
+
+data AISafetyItem = AISafetyItem
+  { year :: String,
+    description :: String,
+    url :: Maybe String
   }
   deriving (Generic, Show, ToJSON, FromJSON)
 

--- a/src/ResumeBuilder/Themes/JoeTheme/Components.hs
+++ b/src/ResumeBuilder/Themes/JoeTheme/Components.hs
@@ -250,3 +250,32 @@ jSectionHeader color fontFamily fontSize enableBorder =
               else ("border-bottom", "none")
           ]
     (h3 ! applyStyles css) . toHtml
+
+jAISafetyItem :: JoeThemeSettings -> AISafetyItem -> Html
+jAISafetyItem themeSettings item = H.div ! applyStyles containerStyles $ do
+  let timeWorkedColor' = timeWorkedColor themeSettings
+      bodyColor' = bodyColor themeSettings
+      linkColor' = linkColor themeSettings
+      bodyFontSize = fontSize3 themeSettings
+
+  -- Year on the left
+  H.span ! applyStyles [("color", timeWorkedColor'), ("white-space", "nowrap"), ("margin-right", "1em")] $
+    toHtml (year item)
+
+  -- Description and URL on the right
+  H.span ! applyStyles [("color", bodyColor')] $ do
+    toHtml (description item)
+    case url item of
+      Nothing -> pure ()
+      Just itemUrl -> do
+        H.span " " -- Space before the URL
+        a ! href (fromString itemUrl) ! target "_blank" ! applyStyles [("color", linkColor'), ("font-size", bodyFontSize)] $
+          toHtml itemUrl
+  where
+    containerStyles =
+      [ ("display", "flex"),
+        ("flex-direction", "row"),
+        ("align-items", "flex-start"), -- Align items to the top
+        ("margin-bottom", "0.5em"), -- Space between items
+        ("text-align", "left") -- Ensure text aligns left
+      ]

--- a/src/ResumeBuilder/Themes/JoeTheme/Components.hs
+++ b/src/ResumeBuilder/Themes/JoeTheme/Components.hs
@@ -4,7 +4,7 @@
 module ResumeBuilder.Themes.JoeTheme.Components where
 
 import Control.Monad (forM_, unless)
-import Data.List (intersperse, isPrefixOf, isSuffixOf)
+import Data.List (intersperse)
 import Data.String (IsString (fromString))
 import ResumeBuilder.ResumeBuilderModel
 import ResumeBuilder.Themes.JoeTheme.Styler (Classes, Styles, applyClasses, applyStyles)
@@ -256,7 +256,6 @@ jAISafetyItem themeSettings item = H.div ! applyStyles sectionContainerStyles $ 
   let bodyColor' = bodyColor themeSettings
       timeWorkedColor' = timeWorkedColor themeSettings
       greyedColor = "#888888" -- A generic grey color for the URL
-      bodyFontSize = fontSize3 themeSettings
 
   -- Main content row (Description and Year)
   H.div ! applyStyles mainRowStyles $ do
@@ -272,37 +271,24 @@ jAISafetyItem themeSettings item = H.div ! applyStyles sectionContainerStyles $ 
   case url item of
     Nothing -> pure ()
     Just itemUrl -> do
-      let cleanedUrl = cleanUrl itemUrl
-      unless (null cleanedUrl) $
+      unless (null itemUrl) $ -- Check if the URL string is not empty
         H.div ! applyStyles urlRowStyles $
-          H.small ! applyStyles [("color", greyedColor), ("font-size", "0.8em")] $ -- Smaller font for URL
-            toHtml cleanedUrl
+          H.small ! applyStyles [("color", greyedColor), ("font-size", "0.8em")] $
+            toHtml itemUrl
   where
     sectionContainerStyles =
       [ ("display", "flex"),
-        ("flex-direction", "column"), -- Changed to column for URL on new line
-        ("margin-bottom", "0.75em"), -- Space between items
+        ("flex-direction", "column"),
+        ("margin-bottom", "0.75em"),
         ("text-align", "left")
       ]
     mainRowStyles =
       [ ("display", "flex"),
         ("flex-direction", "row"),
-        ("justify-content", "space-between"), -- Pushes year to the right
+        ("justify-content", "space-between"),
         ("align-items", "flex-start")
       ]
     urlRowStyles =
       [ ("margin-left", "1.5em"), -- Indentation for the URL
         ("margin-top", "0.25em")  -- Small space between description and URL
       ]
-
--- Helper function to clean URL
-cleanUrl :: String -> String
-cleanUrl = removeTrailingSlash . removeHttpHttps
-  where
-    removeHttpHttps str
-      | "https://" `isPrefixOf` str = drop (length "https://") str
-      | "http://" `isPrefixOf` str = drop (length "http://") str
-      | otherwise = str
-    removeTrailingSlash str
-      | "/" `isSuffixOf` str = take (length str - 1) str
-      | otherwise = str

--- a/src/ResumeBuilder/Themes/JoeTheme/Template.hs
+++ b/src/ResumeBuilder/Themes/JoeTheme/Template.hs
@@ -163,7 +163,7 @@ renderResume config = docTypeHtml $ do
 
       -- AI Safety Exposure section
       renderLongSection (aiSafetyExposureTitle documentTitles')
-        (fmap (jExperienceItem theme' " " "at ") (aiSafetyExposure config))
+        (fmap (jAISafetyItem theme') (aiSafetyExposure config))
 
       -- Work experience section
       renderLongSection (workExperienceTitle documentTitles')


### PR DESCRIPTION
Refactor: Simplify AI Safety Exposure section

- Defined a new data type `AISafetyItem` for simpler AI Safety entries.
- Created a new rendering function `jAISafetyItem` for these entries.
- Updated the template and YAML data to use the new format.
- The new format displays the year on the left and a single line of text (description and optional URL) on the right.