### PR TITLE
Add 'highlight' field and fix YAML format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Agent Instructions for hsresumebuilder
+
+This document provides guidance for AI agents working with the `hsresumebuilder` Haskell project.
+
+## Key Files and Their Purpose:
+
+1.  **`hsresumebuilder.yaml`**:
+    *   **Location**: Project root.
+    *   **Purpose**: This is the primary data file containing the resume content. It's written in YAML format and defines all sections of the resume, such as personal information, work experience, education, etc.
+    *   **Agent Note**: When asked to modify resume content (e.g., add a new job, change a description, or update personal details), this is the file you will most likely need to edit. Pay close attention to the YAML structure, especially for optional fields and lists. Ensure data types match the Haskell definitions in `src/ResumeBuilder/ResumeBuilderModel.hs`.
+
+2.  **`src/ResumeBuilder/ResumeBuilderModel.hs`**:
+    *   **Location**: `src/ResumeBuilder/`
+    *   **Purpose**: Defines the Haskell data types that represent the structure of the resume. These types (e.g., `Preferences`, `ExperienceItem`, `PersonalInfo`) directly correspond to the structure of the `hsresumebuilder.yaml` file.
+    *   **Agent Note**: If you need to add a new field to the resume structure (like the `highlight` field was added to `ExperienceItem`), you must modify the data types here first. The `FromJSON` and `ToJSON` instances are derived generically, so Aeson handles YAML parsing and serialization based on these type definitions.
+
+3.  **`src/ResumeBuilder/Themes/JoeTheme/Components.hs`**:
+    *   **Location**: `src/ResumeBuilder/Themes/JoeTheme/`
+    *   **Purpose**: This file contains Haskell functions (using the Blaze HTML library) that render specific components of the resume into HTML. For example, `jExperienceItem` is responsible for rendering a single job experience entry.
+    *   **Agent Note**: If you need to change *how* a part of the resume is displayed (e.g., change formatting, add new information to the HTML output for an existing data field), you will likely modify functions in this file.
+
+4.  **`src/ResumeBuilder/Themes/JoeTheme/Template.hs`**:
+    *   **Location**: `src/ResumeBuilder/Themes/JoeTheme/`
+    *   **Purpose**: This file defines the overall HTML structure and layout of the resume. It uses functions from `Components.hs` to build the complete HTML page.
+    *   **Agent Note**: Changes to the main sections of the resume or the order in which they appear would typically be made here.
+
+5.  **`src/ResumeBuilder/Lib.hs`**:
+    *   **Location**: `src/ResumeBuilder/`
+    *   **Purpose**: Contains the main application logic. It handles reading the configuration (which includes parsing `hsresumebuilder.yaml`), rendering the resume using the chosen theme and template, and saving the output to `output.html`.
+    *   **Agent Note**: You typically won't need to modify this unless changing core application flow, like input file handling or output generation logic.
+
+6.  **`app/Main.hs`**:
+    *   **Location**: `app/`
+    *   **Purpose**: The main entry point of the executable. It calls functions from `ResumeBuilder.Lib`.
+    *   **Agent Note**: Usually, no modifications are needed here for content or presentation changes.
+
+7.  **`test/Spec.hs`**:
+    *   **Location**: `test/`
+    *   **Purpose**: Contains test cases for the project.
+    *   **Agent Note**: When adding new features or modifying existing logic, it's good practice to add or update tests here to verify correctness. The current test setup is basic; contributions to make it more robust are welcome.
+
+## Common Tasks:
+
+*   **Adding a new field to an experience item**:
+    1.  Modify `ExperienceItem` in `src/ResumeBuilder/ResumeBuilderModel.hs`.
+    2.  Update `jExperienceItem` in `src/ResumeBuilder/Themes/JoeTheme/Components.hs` to display the new field.
+    3.  Add the new field to relevant entries in `hsresumebuilder.yaml`.
+    4.  Consider adding a test to `test/Spec.hs`.
+
+*   **Changing resume content (e.g., job description)**:
+    1.  Directly edit the relevant section in `hsresumebuilder.yaml`.
+
+*   **Changing HTML styling or structure for a specific component**:
+    1.  Modify the relevant rendering function in `src/ResumeBuilder/Themes/JoeTheme/Components.hs`.
+
+## Building and Running:
+
+*   To build: `cabal build`
+*   To run tests: `cabal test`
+*   To generate the resume: `cabal run hsresumebuilder -- hsresumebuilder.yaml` (This will produce `output.html`)
+
+**Agent Self-Correction Note**: Previously, I (Jules) mistakenly focused on `sample_resume.yaml` (a test file I created) instead of the main `hsresumebuilder.yaml` when debugging a YAML formatting issue. Always confirm which YAML file is the source of truth for resume data – it's `hsresumebuilder.yaml` in the project root.

--- a/hsresumebuilder.yaml
+++ b/hsresumebuilder.yaml
@@ -80,8 +80,7 @@ hsResumeBuilder:
         - "I strive to be helpful to others, by writing researched, detailed answers with plenty of code examples. I like to codify existing practices, to remove ambiguity and to give us the opportunity to self-reflect and improve. I reach out to others, building bridges, collaborating and resolving misunderstandings."
     experience:
       - entityName: "Well.co"
-        highlight:
-          - "Designed a programming language for defining health-related challenges and their presentation."
+        highlight: "Designed a programming language for defining health-related challenges and their presentation." # Corrected from list to string
         technologies: "Haskell, Postgres, PureScript, Bash. Nix, Docker, AWS Cognito, Terraform. Mac, Linux. GitHub Copilot."
         responsibilities: "Technical design, implementation, load testing, addressing outages, project management."
         expertise: ""

--- a/src/ResumeBuilder/ResumeBuilderModel.hs
+++ b/src/ResumeBuilder/ResumeBuilderModel.hs
@@ -109,7 +109,8 @@ data ExperienceItem = ExperienceItem
     contexts :: Maybe String,
     extraCurricular :: Maybe String,
     positionName :: [String],
-    timeWorked :: String
+    timeWorked :: String,
+    highlight :: Maybe String
   }
   deriving (Generic, Show, ToJSON, FromJSON)
 

--- a/src/ResumeBuilder/Themes/JoeTheme/Components.hs
+++ b/src/ResumeBuilder/Themes/JoeTheme/Components.hs
@@ -178,6 +178,12 @@ jExperienceItem themeSettings
         let bodyColor' = bodyColor themeSettings
         let bodyFontSize = fontSize3 themeSettings
         let timeWorkedColor' = timeWorkedColor themeSettings
+
+        -- Display highlight if it exists
+        forM_ (highlight body) $ \h -> do
+          H.div ! applyStyles [("margin-bottom", "0.5em")] $ do -- Add some space below the highlight
+            jParagraph bodyColor' bodyFontSize $ H.strong (fromString h)
+
         H.div ! applyStyles [("display", "table")] $ do
           forM_ [ ("Technologies", technologies)
                 , ("Responsibilities", responsibilities)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import ResumeBuilder.ResumeBuilderModel
+import ResumeBuilder.Themes.JoeTheme.Components (jExperienceItem)
+import ResumeBuilder.Themes.JoeTheme.Styler (applyStyles) -- Import if needed for jExperienceItem
+import Text.Blaze.Html5 as H
+import Text.Blaze.Html5.Attributes as A
+import Text.Blaze.Html.Renderer.String (renderHtml)
+import Data.Maybe (fromMaybe)
+
+-- Minimal JoeThemeSettings for testing
+testThemeSettings :: JoeThemeSettings
+testThemeSettings = JoeThemeSettings {
+    bodyColor = "black",
+    jobTitleColor = "blue",
+    nameColor = "green",
+    sectionTitlesColor = "red",
+    sectionTitleBorderEnabled = False,
+    entityNameColor = "purple",
+    positionNameColor = "orange",
+    timeWorkedColor = "cyan",
+    linkColor = "magenta",
+    bodyFontFamily = "Arial",
+    titleFontFamily = "Times New Roman",
+    fontSize1 = "24px",
+    fontSize2 = "18px",
+    fontSize3 = "12px",
+    customStylesheetsToLoad = []
+}
+
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = do
+    putStrLn "Running tests..."
+    testHighlightRendering
+    putStrLn "Tests finished."
+
+testHighlightRendering :: IO ()
+testHighlightRendering = do
+    let experienceWithHighlight = ExperienceItem {
+            entityName = "Test Company",
+            technologies = Just "Haskell, Nix",
+            responsibilities = Just "Coding, Testing",
+            expertise = Nothing,
+            contexts = Nothing,
+            extraCurricular = Nothing,
+            positionName = ["Software Engineer"],
+            timeWorked = "2023-Present",
+            highlight = Just "This is a test highlight."
+        }
+
+    let experienceWithoutHighlight = ExperienceItem {
+            entityName = "Another Company",
+            technologies = Just "Python, Docker",
+            responsibilities = Just "Development, Deployment",
+            expertise = Nothing,
+            contexts = Nothing,
+            extraCurricular = Nothing,
+            positionName = ["DevOps Engineer"],
+            timeWorked = "2021-2022",
+            highlight = Nothing
+        }
+
+    let htmlWithHighlight = renderHtml $ jExperienceItem testThemeSettings " " "at " experienceWithHighlight
+    let htmlWithoutHighlight = renderHtml $ jExperienceItem testThemeSettings " " "at " experienceWithoutHighlight
+
+    let highlightText = "This is a test highlight."
+
+    if highlightText `isInfixOf` htmlWithHighlight
+        then putStrLn "testHighlightRendering (with highlight): PASSED"
+        else putStrLn "testHighlightRendering (with highlight): FAILED - Highlight not found in HTML."
+
+    if not (highlightText `isInfixOf` htmlWithoutHighlight)
+        then putStrLn "testHighlightRendering (without highlight): PASSED"
+        else putStrLn "testHighlightRendering (without highlight): FAILED - Highlight found when it shouldn't be."
+
+-- Helper function to check if a substring exists in a string
+isInfixOf :: String -> String -> Bool
+isInfixOf needle haystack = any (isPrefixOf needle) (tails haystack)
+
+isPrefixOf :: String -> String -> Bool
+isPrefixOf [] _ = True
+isPrefixOf _ [] = False
+isPrefixOf (n:ns) (h:hs) = n == h && isPrefixOf ns hs
+
+tails :: [a] -> [[a]]
+tails [] = [[]]
+tails (x:xs) = (x:xs) : tails xs


### PR DESCRIPTION
From Google Jules:

- Modified `ExperienceItem` in `ResumeBuilderModel.hs` to include an optional `highlight` field (Maybe String).
- Updated `jExperienceItem` in `Themes/JoeTheme/Components.hs` to render the `highlight` string, if present, on the line above other job details.
- Added a basic test case to `test/Spec.hs` to verify rendering of the highlight field.
- Corrected `hsresumebuilder.yaml` to ensure all `highlight` fields are formatted as single YAML strings, resolving a parsing error.