### PR TITLE
Render specific resume items in bold text

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,7 +1,7 @@
 [x] Add "Programming Language Experience" and "AI Safety Exposure" sections.
 [x] Reorganize the "AI Safety Exposure" section to only keep one line of
     explanation and one date range.
-[ ] Make these bold and nothing else (but leave the header as-is):
+[x] Make these bold and nothing else (but leave the header as-is):
     * "using Value Range Analysis to prove the safety of a toy example"
     * "Can we Prove Facts about ML Models via Code Synthesis?"
     * "A programming language guaranteeing that generated code is well-typed."

--- a/hsresumebuilder.yaml
+++ b/hsresumebuilder.yaml
@@ -40,7 +40,7 @@ hsResumeBuilder:
         rightText: "2010"
       - middleText: "McGill University"
         paragraphs:
-          - "Compilers class, course project was a language listing server-side and client-side code in the same function."
+          - "Compilers class, course project was <strong>a language listing server-side and client-side code in the same function</strong>."
           - "AI class, final project was a shallow neural network playing a board game."
         leftText: "B.Sc., major in Computer Science"
         rightText: "2006"
@@ -159,12 +159,12 @@ hsResumeBuilder:
     publications:
       - middleText: "Jang, Gélineau, Monnier, and Pientka"
         paragraphs:
-          - "A programming language guaranteeing that generated code is well-typed."
+          - "<strong>A programming language guaranteeing that generated code is well-typed.</strong>"
         leftText: "Mœbius: Metaprogramming using Contextual Types"
         rightText: "POPL2022"
       - middleText: "Barrett, Christiansen, and Gélineau"
         paragraphs:
-          - "A programming language with type-driven macros."
+          - "<strong>A programming language with type-driven macros.</strong>"
         leftText: "Klister: Predictable Macros for Hindley-Milner"
         rightText: "TyDe2020"
     interestsHobbies:
@@ -175,7 +175,7 @@ hsResumeBuilder:
         positionName: []
         timeWorked: ""
     praise:
-      - middleText: "Haskell superstar and former programming language researcher at MIRI"
+      - middleText: "Haskell superstar and former <strong>programming language researcher at MIRI</strong>"
         paragraphs:
           - "\"Hire this guy.\""
         leftText: "Edward Kmett"
@@ -217,13 +217,13 @@ hsResumeBuilder:
       #   rightText: ""
     aiSafetyExposure:
       - year: "2025"
-        description: "Interactive demo: using Value Range Analysis to prove the safety of a toy example"
+        description: "Interactive demo: <strong>using Value Range Analysis to prove the safety of a toy example</strong>"
         url: "gelisam.com/range-analysis"
       - year: "2025"
         description: "Applied to Safeguarded AI TA1.2 as part of GLAIVe Research"
         url: null
       - year: "2022"
-        description: "Invited talk at Galois, \"Can we Prove Facts about ML Models via Code Synthesis?\""
+        description: "Invited talk at Galois, \"<strong>Can we Prove Facts about ML Models via Code Synthesis?</strong>\""
         url: "youtu.be/-2nFTfXAsmU"
       - year: "2020 – 2022"
         description: "Answered AI Safety questions from comments on Rob Miles's videos as part of his Patreon-only Discord server"

--- a/hsresumebuilder.yaml
+++ b/hsresumebuilder.yaml
@@ -223,7 +223,7 @@ hsResumeBuilder:
         description: "Applied to Safeguarded AI TA1.2 as part of GLAIVe Research"
         url: null
       - year: "2022"
-        description: "Invited talk at Galois, \"<strong>Can we Prove Facts about ML Models via Code Synthesis?</strong>\""
+        description: "Invited talk at Galois, <strong>\"Can we Prove Facts about ML Models via Code Synthesis?\"</strong>"
         url: "youtu.be/-2nFTfXAsmU"
       - year: "2020 – 2022"
         description: "Answered AI Safety questions from comments on Rob Miles's videos as part of his Patreon-only Discord server"

--- a/src/ResumeBuilder/Themes/JoeTheme/Components.hs
+++ b/src/ResumeBuilder/Themes/JoeTheme/Components.hs
@@ -4,8 +4,10 @@
 module ResumeBuilder.Themes.JoeTheme.Components where
 
 import Control.Monad (forM_, unless)
+import Data.Function ((&))
 import Data.List (intersperse)
 import Data.String (IsString (fromString))
+import Text.Blaze.Html (preEscapedString)
 import ResumeBuilder.ResumeBuilderModel
 import ResumeBuilder.Themes.JoeTheme.Styler (Classes, Styles, applyClasses, applyStyles)
 import Text.Blaze.Html5 as H
@@ -153,7 +155,7 @@ jGenericItem themeSettings leftPieces middlePiece rightPiece addSpaceAbove detai
           sequence_ commaSeparatedPieces
         (H.span ! applyStyles [("color", positionNameColor')]) . toHtml $ separator1
         jSmall entityNameColor' . toHtml $ separator2
-        jSmall entityNameColor' $ middlePiece item
+        (middlePiece item) & preEscapedString & jSmall entityNameColor'
       jSmall timeWorkedColor' . toHtml . rightPiece $ item
   renderDetails (details item)
 
@@ -169,7 +171,7 @@ jParagraphGenericItem themeSettings
       ((:[]) . leftText) middleText rightText True paragraphs $ \paragraphs_ -> do
         let bodyColor' = bodyColor themeSettings
         let bodyFontSize = fontSize3 themeSettings
-        forM_ paragraphs_ (jParagraph bodyColor' bodyFontSize)
+        forM_ paragraphs_ (\p -> p & preEscapedString & jParagraph bodyColor' bodyFontSize)
 
 jExperienceItem :: JoeThemeSettings -> String -> String -> ExperienceItem -> Html
 jExperienceItem themeSettings
@@ -269,7 +271,7 @@ jAISafetyItem themeSettings item = H.div ! applyStyles sectionContainerStyles $ 
   H.div ! applyStyles mainRowStyles $ do
     -- Description on the left
     H.span ! applyStyles [("color", bodyColor'), ("flex-grow", "1")] $ do
-      toHtml (description item)
+      preEscapedString (description item)
 
     -- Year on the right
     H.span ! applyStyles [("color", timeWorkedColor'), ("white-space", "nowrap"), ("margin-left", "1em")] $

--- a/src/ResumeBuilder/Themes/JoeTheme/Components.hs
+++ b/src/ResumeBuilder/Themes/JoeTheme/Components.hs
@@ -149,9 +149,9 @@ jGenericItem themeSettings leftPieces middlePiece rightPiece addSpaceAbove detai
       H.span $ do
         (H.span ! applyStyles [("color", positionNameColor')]) $ do
           let stringPieces = leftPieces item
-              htmlPieces = fmap toHtml stringPieces
-              boldPieces = fmap H.strong htmlPieces
-              commaSeparatedPieces = intersperse ", " boldPieces
+              htmlPieces = fmap preEscapedString stringPieces
+              -- Boldness is now controlled by <strong> tags in YAML
+              commaSeparatedPieces = intersperse ", " htmlPieces
           sequence_ commaSeparatedPieces
         (H.span ! applyStyles [("color", positionNameColor')]) . toHtml $ separator1
         jSmall entityNameColor' . toHtml $ separator2


### PR DESCRIPTION
From Google Jules:

This change modifies the resume generation:
- Updates Haskell code to use `preEscapedString` for specific fields, allowing raw HTML.
- Adds `<strong>` tags to the relevant strings in `hsresumebuilder.yaml`.
- Marks the corresponding TODO item as complete.